### PR TITLE
Remove deprecated data_provider

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,6 @@
   "dependencies": [
     {"name":"puppetlabs-stdlib","version_requirement":">= 4.13.1 < 5.0.0"}
   ],
-  "data_provider": "hiera",
   "operatingsystem_support": [
     {"operatingsystem": "CentOS", "operatingsystemrelease": ["6","7"]},
     {"operatingsystem": "RedHat", "operatingsystemrelease": ["6","7"]},


### PR DESCRIPTION
So we get rid of this warning:
    Defining "data_provider": "hiera" in metadata.json is deprecated