### PR TITLE
Use Hiera 5 format

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,18 +1,18 @@
 ---
-version: 4
-datadir: data
+version: 5
+
+defaults:
+  datadir: data
+  data_hash: yaml_data
+
 hierarchy:
   - name: "Full Version"
-    backend: yaml
-    path: "release/%{facts.os.name}-%{facts.os.release.full}"
+    path: "release/%{facts.os.name}-%{facts.os.release.full}.yaml"
   - name: "Major Version"
-    backend: yaml
-    path: "release/%{facts.os.name}-%{facts.os.release.major}"
+    path: "release/%{facts.os.name}-%{facts.os.release.major}.yaml"
   - name: "Distribution Name"
-    backend: yaml
-    path: "distribution/%{facts.os.name}"
+    path: "distribution/%{facts.os.name}.yaml"
   - name: "Operating System Family"
-    backend: yaml
-    path: "osfamily/%{facts.os.family}"
+    path: "osfamily/%{facts.os.family}.yaml"
   - name: "common"
-    backend: yaml
+    path: "common.yaml"


### PR DESCRIPTION
v4 is deprecated and generates this warning:
```
Warning: /etc/puppetlabs/code/environments/production/modules/chrony/hiera.yaml: Use of 'hiera.yaml' version 4 is deprecated. It should be converted to version 5
   (in /etc/puppetlabs/code/environments/production/modules/chrony/hiera.yaml)
```